### PR TITLE
filter values for flesch and sentence length

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 e1839a8 = {path = ".",extras = ["nlp", "s3driver"],editable = true}
-textstat = "*"
+textstat = "https://github.com/jnelson16/textstat.git"
 
 [dev-packages]
 "pytest-flake8" = "*"

--- a/quantgov/__init__.py
+++ b/quantgov/__init__.py
@@ -4,4 +4,4 @@ from __future__ import (absolute_import, division, print_function,
 from . import corpus, nlp, ml, utils
 from .utils import load_driver
 
-__version__ = '0.6.1'
+__version__ = '0.6.3'

--- a/quantgov/__init__.py
+++ b/quantgov/__init__.py
@@ -4,4 +4,4 @@ from __future__ import (absolute_import, division, print_function,
 from . import corpus, nlp, ml, utils
 from .utils import load_driver
 
-__version__ = '0.7.0.dev'
+__version__ = '0.6.1'

--- a/quantgov/__main__.py
+++ b/quantgov/__main__.py
@@ -179,9 +179,10 @@ def run_corpus_builtin(args):
         builtin.process_document,
         **func_args
     )
-    for i in quantgov.utils.lazy_parallel(partial, driver.stream()):
-        writer.writerow(i)
-        args.outfile.flush()
+    for result in quantgov.utils.lazy_parallel(partial, driver.stream()):
+        if result:
+            writer.writerow(result)
+            args.outfile.flush()
 
 
 def run_estimator(args):

--- a/quantgov/corpus.py
+++ b/quantgov/corpus.py
@@ -83,11 +83,11 @@ class CorpusDriver(object):
                     "Index Labels must be a string or sequence of strings")
         self.index_labels = index_labels
 
-    def get_streamer(self):
+    def get_streamer(self, *args, **kwargs):
         """
         Return a CorpusStreamer object that wraps this corpus's stream method.
         """
-        return CorpusStreamer(self.stream())
+        return CorpusStreamer(self.stream(*args, **kwargs))
 
     def stream(self):
         """

--- a/quantgov/ml/estimation.py
+++ b/quantgov/ml/estimation.py
@@ -149,7 +149,7 @@ def estimate_probability_multilabel_multiclass(estimator, streamer, precision):
     )
 
 
-def estimate(estimator, corpus, probability, precision=4):
+def estimate(estimator, corpus, probability, precision=4, *args, **kwargs):
     """
     Estimate label values for documents in corpus
 
@@ -160,7 +160,7 @@ def estimate(estimator, corpus, probability, precision=4):
         * **probability**: if True, predict probability
         * **precision**: precision for probability prediction
     """
-    streamer = corpus.get_streamer()
+    streamer = corpus.get_streamer(*args, **kwargs)
     if probability:
         if estimator.multilabel:
             if estimator.multiclass:  # Multilabel-multiclass probability

--- a/quantgov/nlp.py
+++ b/quantgov/nlp.py
@@ -247,6 +247,15 @@ class SentenceLength():
                     'help': 'decimal places to round',
                     'default': 2
                 }
+            ),
+            utils.CLIArg(
+                flags=('--threshold'),
+                kwargs={
+                    'help': ('maximum average sentence length to allow '
+                             '(set to 0 for no filtering)'),
+                    'type': int,
+                    'default': 100
+                }
             )
         ]
     )
@@ -258,16 +267,23 @@ class SentenceLength():
     @staticmethod
     @check_nltk
     @check_textblob
-    def process_document(doc, precision):
+    def process_document(doc, precision, threshold):
         sentences = textblob.TextBlob(doc.text).sentences
+        if not len(sentences):
+            return doc.index + (None,)
         # Allows for rounding to a specified number of decimals
-        if precision:
-            return doc.index + (round(sum(len(
+        elif precision:
+            sentence_length = round(sum(len(
                 sentence.words) for sentence in sentences) / len(sentences),
-                int(precision)),)
+                int(precision))
         else:
-            return doc.index + (sum(len(
-                sentence.words) for sentence in sentences) / len(sentences),)
+            sentence_length = sum(len(
+                sentence.words) for sentence in sentences) / len(sentences)
+        # Filters values based on threshold
+        if not threshold or sentence_length < threshold:
+            return doc.index + (sentence_length,)
+        else:
+            return doc.index + (None,)
 
 
 commands['sentence_length'] = SentenceLength
@@ -325,7 +341,17 @@ class FleschReadingEase():
 
     cli = utils.CLISpec(
         help='Flesch Reading Ease metric',
-        arguments=[]
+        arguments=[
+            utils.CLIArg(
+                flags=('--threshold'),
+                kwargs={
+                    'help': ('minimum score to allow '
+                             '(set to 0 for no filtering)'),
+                    'type': int,
+                    'default': -100
+                }
+            )
+        ]
     )
 
     @staticmethod
@@ -334,10 +360,13 @@ class FleschReadingEase():
 
     @staticmethod
     @check_textstat
-    def process_document(doc):
+    def process_document(doc, threshold):
         score = textstat.flesch_reading_ease(doc.text)
-        # Allows for rounding to a specified number of decimals
-        return doc.index + (int(score),)
+        # Filters values based on threshold
+        if not threshold or score > threshold:
+            return doc.index + (int(score),)
+        else:
+            return doc.index + (None,)
 
 
 commands['flesch_reading_ease'] = FleschReadingEase


### PR DESCRIPTION
Uses @jnelson16's version of textstat for Flesch scores, which uses textblob to measure sentence length.

Filters Flesch scores and average sentence lengths to be greater than -100 and less than 100 respectively (by default, filtering value can be changed with CLI argument `--threshold`).